### PR TITLE
accelerate structToJsonTagMap

### DIFF
--- a/logger/main.go
+++ b/logger/main.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
+	"reflect"
+	"strings"
 
 	"github.com/fluent/fluent-logger-golang/fluent"
 	"github.com/nlopes/slack"
@@ -13,10 +14,22 @@ import (
 
 func structToJsonTagMap(data interface{}) map[string]interface{} {
 	result := make(map[string]interface{})
-
-	b, _ := json.Marshal(data)
-	json.Unmarshal(b, &result)
-
+	typ := reflect.TypeOf(data)
+	// should check data is struct or not
+	val := reflect.ValueOf(data)
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		vi := val.FieldByName(field.Name).Interface()
+		// if field is struct, convert recursively
+		if field.Type.Kind() == reflect.Struct {
+			vi = structToJsonTagMap(vi)
+		}
+		if tag, ok := field.Tag.Lookup("json"); ok {
+			result[tag] = vi
+			continue
+		}
+		result[strings.ToLower(field.Name)] = vi
+	}
 	return result
 }
 

--- a/logger/main_test.go
+++ b/logger/main_test.go
@@ -1,0 +1,89 @@
+package main_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type Hoge struct {
+	Foo  string `json:"foo"`
+	Bar  string `json:"bar"`
+	Baz  string `json:"baz"`
+	Fuga Fuga   `json:"fuga"`
+}
+
+type Fuga struct {
+	Piyo string `json:"piyo"`
+}
+
+var (
+	hoge   = Hoge{Foo: "foo", Bar: "bar", Baz: "baz", Fuga: Fuga{Piyo: "piyo"}}
+	expect = map[string]interface{}{"foo": "foo", "bar": "bar", "baz": "baz", "fuga": map[string]interface{}{"piyo": "piyo"}}
+)
+
+// old
+func MarshalUnmarshal(data interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	b, _ := json.Marshal(data)
+	json.Unmarshal(b, &result)
+
+	return result
+}
+
+// new
+func Reflect(data interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	typ := reflect.TypeOf(data)
+	// should check data is struct or not
+	val := reflect.ValueOf(data)
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		vi := val.FieldByName(field.Name).Interface()
+		// if field is struct, convert recursively
+		if field.Type.Kind() == reflect.Struct {
+			vi = Reflect(vi)
+		}
+		if tag, ok := field.Tag.Lookup("json"); ok {
+			result[tag] = vi
+			continue
+		}
+		result[strings.ToLower(field.Name)] = vi
+	}
+	return result
+}
+
+/* test old and new function is same*/
+
+func TestMarshalUnmarshal(t *testing.T) {
+	out := MarshalUnmarshal(hoge)
+	if !reflect.DeepEqual(out, expect) {
+		t.Errorf("%s != %s", out, expect)
+	}
+}
+
+func TestReflect(t *testing.T) {
+	out := Reflect(hoge)
+	for k, v := range out {
+		t.Logf("%s:%s : %s:%s", k, reflect.TypeOf(k), v, reflect.TypeOf(v))
+	}
+	if !reflect.DeepEqual(out, expect) {
+		t.Errorf("%s != %s", out, expect)
+	}
+}
+
+/* benchmark */
+
+func BenchmarkMarshalUnmarshal(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		MarshalUnmarshal(hoge)
+	}
+}
+
+func BenchmarkReflect(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Reflect(hoge)
+	}
+}


### PR DESCRIPTION
If you want to convert struct to map, you can use `reflect` package (`encoding/json` should be use only convert struct to JSON string or JSON string to struct).
Using "encoding/json" as converter for this purpose makes difficult to understand without comments and make slower.

The following is the result of `go test -bench .` in `logger` directory.

```
goos: linux
goarch: amd64
pkg: github.com/nasa9084/slack-to-fluentd/logger
BenchmarkMarshalUnmarshal-4   	  200000	      9289 ns/op
BenchmarkReflect-4            	  500000	      3092 ns/op
PASS
ok  	github.com/nasa9084/slack-to-fluentd/logger	3.550s
```